### PR TITLE
refactor(d1): throw a better error if binding not found

### DIFF
--- a/src/connectors/cloudflare-d1.ts
+++ b/src/connectors/cloudflare-d1.ts
@@ -8,7 +8,7 @@ export default function sqliteConnector(options: ConnectorOptions) {
   const getDB = () => {
     const binding = globalThis.__cf_env__?.[options.bindingName];
     if (!binding) {
-      throw new Error(`[db0] [d1] binding ${options.bindingName} not found`);
+      throw new Error(`[db0] [d1] binding \`${options.bindingName}\` not found`);
     }
     return binding;
   }

--- a/src/connectors/cloudflare-d1.ts
+++ b/src/connectors/cloudflare-d1.ts
@@ -5,7 +5,13 @@ export interface ConnectorOptions {
 }
 
 export default function sqliteConnector(options: ConnectorOptions) {
-  const getDB = () => globalThis.__cf_env__[options.bindingName];
+  const getDB = () => {
+    const binding = globalThis.__cf_env__?.[options.bindingName];
+    if (!binding) {
+      throw new Error(`D1 binding ${options.bindingName} not found`);
+    }
+    return binding;
+  }
 
   return <Connector>{
     name: "cloudflare-d1",

--- a/src/connectors/cloudflare-d1.ts
+++ b/src/connectors/cloudflare-d1.ts
@@ -8,7 +8,7 @@ export default function sqliteConnector(options: ConnectorOptions) {
   const getDB = () => {
     const binding = globalThis.__cf_env__?.[options.bindingName];
     if (!binding) {
-      throw new Error(`D1 binding ${options.bindingName} not found`);
+      throw new Error(`[db0] [d1] binding ${options.bindingName} not found`);
     }
     return binding;
   }


### PR DESCRIPTION
Before:

```bash
[nitro] [unhandledRejection] TypeError: Cannot read properties of undefined (reading 'TEST')
    at getDB (file:///Users/atinux/Projects/unjs/nitro/node_modules/.pnpm/db0@0.1.3_better-sqlite3@9.4.3/node_modules/db0/connectors/cloudflare-d1.mjs:2:44)
```

After:

```bash
[nitro] [unhandledRejection] Error: D1 binding TEST not found
    at getDB (file:///Users/atinux/Projects/unjs/db0/connectors/cloudflare-d1.mjs:5:13)
    at Object.prepare (file:///Users/atinux/Projects/unjs/db0/connectors/cloudflare-d1.mjs:13:21)
```