### PR TITLE
refactor(postgres): throw better error on connection fail

### DIFF
--- a/src/connectors/postgresql.ts
+++ b/src/connectors/postgresql.ts
@@ -11,10 +11,17 @@ export default function sqliteConnector(opts: ConnectorOptions) {
       return _client;
     }
     const client = new Client("url" in opts ? opts.url : opts);
-    _client = client.connect().then(() => {
-      _client = client;
-      return _client;
-    });
+    _client = client
+      .connect()
+      .then(() => {
+        _client = client;
+        return _client;
+      })
+      .catch((error: Error) => {
+        error.message += ` - could not connect to Postgres DB at "${"url" in opts ? opts.url : opts}"`;
+
+        throw error;
+      });
     return _client;
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

currently, if no connection can be established the error simply says

`ECONNREFUSED: Failed to connect`

When using db0 in e.g. Nitro this does not tell you a lot.
 With this PR the message looks like this:

`ECONNREFUSED: Failed to connect - could not connect to Postgres DB at ""`

this clearly tells you that something is wrong with your postgres db

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

#### Note

currently, the connector in the [postgresql.ts](https://github.com/unjs/db0/blob/4b7133ca1f926e7d9eeaf04197eda1041137b26f/src/connectors/postgresql.ts#L7) is called `sqliteConnector`. Which I don't think it should. If you agree let me know and I will quickly create a PR for it.