### PR TITLE
docs(integrations/drizzle): Fix TypeScript Type Hinting Errors

### DIFF
--- a/docs/3.integrations/drizzle.md
+++ b/docs/3.integrations/drizzle.md
@@ -13,7 +13,7 @@ icon: simple-icons:drizzle
 ```ts [index.ts]
 import { createDatabase } from "db0";
 import sqlite from "db0/connectors/better-sqlite3";
-import { drizzle } from "db0/integrations/drizzle";
+import { drizzle } from 'db0/integrations/drizzle/index';
 import { sqliteTable, text, numeric } from "drizzle-orm/sqlite-core";
 
 // Initialize DB instance


### PR DESCRIPTION
docs(integrations/drizzle): Fix TypeScript Type Hinting Errors

Updated the `drizzle` import path to directly reference `index.d.ts`, resolving the issue where types could not be found in type hints.

fix: https://github.com/unjs/db0/issues/106