### PR TITLE
refactor(postgresql): correct function name

### DIFF
--- a/src/connectors/postgresql.ts
+++ b/src/connectors/postgresql.ts
@@ -4,7 +4,7 @@ import type { Connector, Statement } from "../types";
 
 export type ConnectorOptions = { url: string } | ClientConfig;
 
-export default function sqliteConnector(opts: ConnectorOptions) {
+export default function postgresqlConnector(opts: ConnectorOptions) {
   let _client: undefined | Client | Promise<Client>;
   function getClient() {
     if (_client) {


### PR DESCRIPTION
Rename default postgresql.ts export to match postgresqlConnector for typehinted import.

Resolves #105 
