### PR TITLE
fix(typings): consistency in results of sql method

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -31,6 +31,7 @@ export function createDatabase(connector: Connector): Database {
         const rows = await connector.prepare(sql).all(...params);
         return {
           rows,
+          success: true,
         };
       } else {
         const res = await connector.prepare(sql).run(...params);

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ type DefaultSQLResult = {
   changes?: number;
   error?: string;
   rows?: { id?: string | number; [key: string]: unknown }[];
+  success?: boolean
 };
 
 export interface Database {


### PR DESCRIPTION
Resolves #99 

TLDR; on issue:
Since code runs differently for select queries and non-select queries, correct typings are not produced.

This PR adds optional success field in default type, essentially, making required type a subset, and updated success flag when select query runs.
