### PR TITLE
fix: add missing `mysql` to `connectors` map

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export const connectors = {
   bun: "db0/connectors/bun-sqlite",
   "bun-sqlite": "db0/connectors/bun-sqlite",
   planetscale: "db0/connectors/planetscale",
+  mysql: "db0/connectors/mysql2",
 } as const;
 
 /**


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #126 
