### PR TITLE
feat(pglite): use async init

### DIFF
--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -1,20 +1,22 @@
-import { PGlite, type PGliteOptions } from "@electric-sql/pglite";
+import type { PGliteOptions, PGliteInterfaceExtensions } from "@electric-sql/pglite";
+import { PGlite as PGliteClass } from "@electric-sql/pglite";
 import type { Connector, Statement } from "../types";
 
 export type ConnectorOptions = PGliteOptions
+export type PGlite<TOptions extends PGliteOptions = ConnectorOptions> = PGliteClass & PGliteInterfaceExtensions<TOptions['extensions']>
 
 export default function pgliteConnector(opts: ConnectorOptions = {}) {
   let _client: PGlite | undefined;
 
-  function getClient(): PGlite {
+  async function getClient(): Promise<PGlite> {
     if (_client) {
       return _client;
     }
-    _client = new PGlite(opts);
+    _client = await PGliteClass.create(opts);
     return _client;
   }
 
-  async function query(sql: string, params: unknown[] = []) {
+  async function query(sql: string, params: unknown[] = undefined) {
     const client = await getClient();
     const normalizedSql = normalizeParams(sql);
     const result = await client.query(normalizedSql, params);

--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -7,14 +7,10 @@ export type ConnectorOptions = PGliteOptions
 export default function pgliteConnector<TOptions extends ConnectorOptions>(opts?: TOptions) {
   type PGLiteInstance = PGlite & PGliteInterfaceExtensions<TOptions['extensions']>
 
-  let _client: undefined | PGLiteInstance;
+  let _client: undefined | PGLiteInstance | Promise<PGLiteInstance>;
 
-  async function getClient(): Promise<PGLiteInstance> {
-    if (_client) {
-      return _client;
-    }
-    _client = await PGlite.create(opts);
-    return _client;
+  function getClient() {
+    return _client ||= PGlite.create(opts).then((res) => _client = res)
   }
 
   async function query(sql: string, params: unknown[] = undefined) {

--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -8,7 +8,7 @@ export type PGlite<TOptions extends PGliteOptions = ConnectorOptions> = PGliteCl
 export default function pgliteConnector(opts: ConnectorOptions = {}) {
   let _client: PGlite | undefined;
 
-  async function getClient(): Promise<PGlite> {
+  async function getClient(): Promise<PGlite<typeof opts>> {
     if (_client) {
       return _client;
     }

--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -1,18 +1,17 @@
 import type { PGliteOptions, PGliteInterfaceExtensions } from "@electric-sql/pglite";
-import { PGlite as PGliteClass } from "@electric-sql/pglite";
+import { PGlite } from "@electric-sql/pglite";
 import type { Connector, Statement } from "../types";
 
 export type ConnectorOptions = PGliteOptions
-export type PGlite<TOptions extends PGliteOptions = ConnectorOptions> = PGliteClass & PGliteInterfaceExtensions<TOptions['extensions']>
 
-export default function pgliteConnector(opts: ConnectorOptions = {}) {
-  let _client: PGlite | undefined;
+export default function pgliteConnector<TOptions extends ConnectorOptions>(opts?: TOptions) {
+  let _client: PGlite & PGliteInterfaceExtensions<TOptions['extensions']> | undefined;
 
-  async function getClient(): Promise<PGlite<typeof opts>> {
+  async function getClient(): Promise<PGlite & PGliteInterfaceExtensions<TOptions['extensions']>> {
     if (_client) {
       return _client;
     }
-    _client = await PGliteClass.create(opts);
+    _client = await PGlite.create(opts);
     return _client;
   }
 
@@ -23,7 +22,7 @@ export default function pgliteConnector(opts: ConnectorOptions = {}) {
     return result;
   }
 
-  return <Connector<PGlite>>{
+  return <Connector<PGlite & PGliteInterfaceExtensions<TOptions['extensions']>>>{
     name: "pglite",
     dialect: "postgresql",
     getInstance: () => getClient(),

--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -5,9 +5,11 @@ import type { Connector, Statement } from "../types";
 export type ConnectorOptions = PGliteOptions
 
 export default function pgliteConnector<TOptions extends ConnectorOptions>(opts?: TOptions) {
-  let _client: PGlite & PGliteInterfaceExtensions<TOptions['extensions']> | undefined;
+  type PGLiteInstance = PGlite & PGliteInterfaceExtensions<TOptions['extensions']>
 
-  async function getClient(): Promise<PGlite & PGliteInterfaceExtensions<TOptions['extensions']>> {
+  let _client: undefined | PGLiteInstance;
+
+  async function getClient(): Promise<PGLiteInstance> {
     if (_client) {
       return _client;
     }
@@ -22,7 +24,7 @@ export default function pgliteConnector<TOptions extends ConnectorOptions>(opts?
     return result;
   }
 
-  return <Connector<PGlite & PGliteInterfaceExtensions<TOptions['extensions']>>>{
+  return <Connector<PGLiteInstance>>{
     name: "pglite",
     dialect: "postgresql",
     getInstance: () => getClient(),


### PR DESCRIPTION
Proposed in https://github.com/sandros94/nuxt-pglite/issues/7, these changes improve typing for newly created PGlite instance that do have extensions added.

This also make sure that the PGlite instance is ready before executing any query (`.create` internally also awaits for `.waitReady`).

I've also changed the following default because in rare occasions PGlite forcefully tries to find `params` in an empty array, hanging without notice:
```diff
-async function query(sql: string, params: unknown[] = []) {
+async function query(sql: string, params: unknown[] = undefined) {
``` 