### PR TITLE
feat: export database instances

### DIFF
--- a/src/connectors/better-sqlite3.ts
+++ b/src/connectors/better-sqlite3.ts
@@ -32,7 +32,7 @@ export default function sqliteConnector(opts: ConnectorOptions) {
   return <Connector<Database.Database>>{
     name: "sqlite",
     dialect: "sqlite",
-    getInstance: async () => getDB(),
+    getInstance: () => getDB(),
     exec(sql: string) {
       return getDB().exec(sql);
     },

--- a/src/connectors/better-sqlite3.ts
+++ b/src/connectors/better-sqlite3.ts
@@ -29,9 +29,10 @@ export default function sqliteConnector(opts: ConnectorOptions) {
     return _db;
   };
 
-  return <Connector>{
+  return <Connector<Database.Database>>{
     name: "sqlite",
     dialect: "sqlite",
+    getInstance: async () => getDB(),
     exec(sql: string) {
       return getDB().exec(sql);
     },

--- a/src/connectors/bun-sqlite.ts
+++ b/src/connectors/bun-sqlite.ts
@@ -32,7 +32,7 @@ export default function bunSqliteConnector(opts: ConnectorOptions) {
   return <Connector<Database>>{
     name: "sqlite",
     dialect: "sqlite",
-    getInstance: async () => getDB(),
+    getInstance: () => getDB(),
     exec(sql: string) {
       return getDB().exec(sql);
     },

--- a/src/connectors/bun-sqlite.ts
+++ b/src/connectors/bun-sqlite.ts
@@ -29,9 +29,10 @@ export default function bunSqliteConnector(opts: ConnectorOptions) {
     return _db;
   };
 
-  return <Connector>{
+  return <Connector<Database>>{
     name: "sqlite",
     dialect: "sqlite",
+    getInstance: async () => getDB(),
     exec(sql: string) {
       return getDB().exec(sql);
     },

--- a/src/connectors/cloudflare-d1.ts
+++ b/src/connectors/cloudflare-d1.ts
@@ -17,7 +17,7 @@ export default function cloudflareD1Connector(options: ConnectorOptions) {
   return <Connector>{
     name: "cloudflare-d1",
     dialect: "sqlite",
-    getInstance: async () => getDB(),
+    getInstance: () => getDB(),
     exec: (sql: string) => getDB().exec(sql),
     prepare: (sql: string) => {
       const _stmt = getDB().prepare(sql);

--- a/src/connectors/cloudflare-d1.ts
+++ b/src/connectors/cloudflare-d1.ts
@@ -17,6 +17,7 @@ export default function cloudflareD1Connector(options: ConnectorOptions) {
   return <Connector>{
     name: "cloudflare-d1",
     dialect: "sqlite",
+    getInstance: async () => getDB(),
     exec: (sql: string) => getDB().exec(sql),
     prepare: (sql: string) => {
       const _stmt = getDB().prepare(sql);

--- a/src/connectors/libsql/core.ts
+++ b/src/connectors/libsql/core.ts
@@ -12,9 +12,10 @@ export default function libSqlCoreConnector(opts: ConnectorOptions) {
     return client.execute(sql);
   }
 
-  return <Connector>{
+  return <Connector<Client>>{
     name: opts.name || "libsql-core",
     dialect: "libsql",
+    getInstance: async () => opts.getClient(),
     exec(sql: string) {
       return query(sql);
     },

--- a/src/connectors/mysql2.ts
+++ b/src/connectors/mysql2.ts
@@ -16,9 +16,10 @@ export default function mysqlConnector(opts: mysql.ConnectionOptions) {
     return _connection;
   };
 
-  return <Connector>{
+  return <Connector<mysql.Connection>>{
     name: "mysql",
     dialect: "mysql",
+    getInstance: async () => getConnection(),
     exec(sql: string) {
       return getConnection().then((c) => c.query(sql).then((res) => res[0]));
     },

--- a/src/connectors/mysql2.ts
+++ b/src/connectors/mysql2.ts
@@ -21,7 +21,7 @@ export default function mysqlConnector(opts: ConnectorOptions) {
   return <Connector<mysql.Connection>>{
     name: "mysql",
     dialect: "mysql",
-    getInstance: async () => getConnection(),
+    getInstance: () => getConnection(),
     exec(sql: string) {
       return getConnection().then((c) => c.query(sql).then((res) => res[0]));
     },

--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -24,7 +24,7 @@ export default function pgliteConnector(opts: ConnectorOptions = {}) {
   return <Connector<PGlite>>{
     name: "pglite",
     dialect: "postgresql",
-    getInstance: async () => getClient(),
+    getInstance: () => getClient(),
     exec(sql: string) {
       return query(sql);
     },

--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -21,9 +21,10 @@ export default function pgliteConnector(opts: ConnectorOptions = {}) {
     return result;
   }
 
-  return <Connector>{
+  return <Connector<PGlite>>{
     name: "pglite",
     dialect: "postgresql",
+    getInstance: async () => getClient(),
     exec(sql: string) {
       return query(sql);
     },

--- a/src/connectors/planetscale.ts
+++ b/src/connectors/planetscale.ts
@@ -25,7 +25,7 @@ export default function planetscaleConnector(opts: ConnectorOptions) {
   return <Connector<Client>>{
     name: "planetscale",
     dialect: "mysql",
-    getInstance: async () => getClient(),
+    getInstance: () => getClient(),
     exec(sql: string) {
       return query(sql);
     },

--- a/src/connectors/planetscale.ts
+++ b/src/connectors/planetscale.ts
@@ -20,9 +20,10 @@ export default function planetscaleConnector(opts: Config) {
     return client.execute(sql, params);
   }
 
-  return <Connector>{
+  return <Connector<Client>>{
     name: "planetscale",
     dialect: "mysql",
+    getInstance: async () => getClient(),
     exec(sql: string) {
       return query(sql);
     },

--- a/src/connectors/postgresql.ts
+++ b/src/connectors/postgresql.ts
@@ -26,7 +26,7 @@ export default function postgresqlConnector(opts: ConnectorOptions) {
   return <Connector<pg.Client>>{
     name: "postgresql",
     dialect: "postgresql",
-    getInstance: async () => getClient(),
+    getInstance: () => getClient(),
     exec(sql: string) {
       return query(sql);
     },

--- a/src/connectors/postgresql.ts
+++ b/src/connectors/postgresql.ts
@@ -23,9 +23,10 @@ export default function postgresqlConnector(opts: ConnectorOptions) {
     return client.query(normalizeParams(sql), params);
   }
 
-  return <Connector>{
+  return <Connector<pg.Client>>{
     name: "postgresql",
     dialect: "postgresql",
+    getInstance: async () => getClient(),
     exec(sql: string) {
       return query(sql);
     },

--- a/src/database.ts
+++ b/src/database.ts
@@ -11,8 +11,10 @@ const SQL_WITH_RES_RE = /^select/i;
  * @param {Connector} connector - The database connector used to execute and prepare SQL statements. See {@link Connector}.
  * @returns {Database} The database interface that allows SQL operations. See {@link Database}.
  */
-export function createDatabase(connector: Connector): Database {
-  return <Database>{
+export function createDatabase<TConnector extends Connector = Connector>(
+  connector: TConnector,
+): Database<TConnector> {
+  return <Database<TConnector>>{
     get dialect() {
       return connector.dialect;
     },

--- a/src/database.ts
+++ b/src/database.ts
@@ -19,8 +19,8 @@ export function createDatabase<TConnector extends Connector = Connector>(
       return connector.dialect;
     },
 
-    get getInstance() {
-      return connector.getInstance;
+    getInstance() {
+      return connector.getInstance();
     },
 
     exec: (sql: string) => {

--- a/src/database.ts
+++ b/src/database.ts
@@ -19,6 +19,10 @@ export function createDatabase<TConnector extends Connector = Connector>(
       return connector.dialect;
     },
 
+    get getInstance() {
+      return connector.getInstance;
+    },
+
     exec: (sql: string) => {
       return Promise.resolve(connector.exec(sql));
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type ExecResult = unknown;
 /**
  * Defines a database connector for executing SQL queries and preparing statements.
  */
-export type Connector = {
+export type Connector<TInstance = any> = {
   /**
    * The name of the connector.
    */
@@ -53,6 +53,11 @@ export type Connector = {
    * The SQL dialect used by the connector.
    */
   dialect: SQLDialect;
+
+  /**
+   * The client instance used internally.
+   */
+  getInstance: () => Promise<TInstance>;
 
   /**
    * Executes an SQL query directly and returns the result.
@@ -79,8 +84,14 @@ type DefaultSQLResult = {
   rows?: { id?: string | number; [key: string]: unknown }[];
 };
 
-export interface Database {
+export interface Database<TConnector extends Connector = Connector> {
   readonly dialect: SQLDialect;
+
+  /**
+   * The client instance used internally.
+   * @returns {Promise<TInstance>} A promise that resolves with the client instance.
+   */
+  getInstance: () => Promise<TConnector["getInstance"]>;
 
   /**
    * Executes a raw SQL string.

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export type Connector<TInstance = any> = {
   /**
    * The client instance used internally.
    */
-  getInstance: () => Promise<TInstance>;
+  getInstance: () => TInstance | Promise<TInstance>;
 
   /**
    * Executes an SQL query directly and returns the result.

--- a/test/connectors/_tests.ts
+++ b/test/connectors/_tests.ts
@@ -9,6 +9,11 @@ export function testConnector<TConnector extends Connector = Connector>(opts: { 
 
   const userId = "1001";
 
+  it("instance matches", async () => {
+    const instance = await db.getInstance();
+    expect(instance).toBe(await opts.connector.getInstance());
+  })
+
   it("dialect matches", () => {
     expect(db.dialect).toBe(opts.dialect);
   })

--- a/test/connectors/_tests.ts
+++ b/test/connectors/_tests.ts
@@ -11,6 +11,7 @@ export function testConnector<TConnector extends Connector = Connector>(opts: { 
 
   it("instance matches", async () => {
     const instance = await db.getInstance();
+    expect(instance).toBeDefined();
     expect(instance).toBe(await opts.connector.getInstance());
   })
 

--- a/test/connectors/_tests.ts
+++ b/test/connectors/_tests.ts
@@ -1,8 +1,8 @@
 import { beforeAll, expect, it } from "vitest";
 import { Connector, Database, createDatabase, type SQLDialect } from "../../src";
 
-export function testConnector(opts: { connector: Connector, dialect: SQLDialect }) {
-  let db: Database;
+export function testConnector<TConnector extends Connector = Connector>(opts: { connector: TConnector, dialect: SQLDialect }) {
+  let db: Database<TConnector>;
   beforeAll(() => {
     db = createDatabase(opts.connector);
   });

--- a/test/integrations/drizzle.test.ts
+++ b/test/integrations/drizzle.test.ts
@@ -17,7 +17,7 @@ describe("integrations: drizzle: better-sqlite3", () => {
   });
 
   let drizzleDb: DrizzleDatabase;
-  let db: Database;
+  let db: Database<ReturnType<typeof sqliteConnector>>;
 
   beforeAll(async () => {
     db = createDatabase(sqliteConnector({}));
@@ -57,7 +57,7 @@ describe.runIf(process.env.POSTGRESQL_URL)("integrations: drizzle: postgres", ()
   });
 
   let drizzleDb: DrizzleDatabase;
-  let db: Database;
+  let db: Database<ReturnType<typeof pgConnector>>;
 
   beforeAll(async () => {
     db = createDatabase(pgConnector({

--- a/test/integrations/drizzle.test.ts
+++ b/test/integrations/drizzle.test.ts
@@ -17,7 +17,7 @@ describe("integrations: drizzle: better-sqlite3", () => {
   });
 
   let drizzleDb: DrizzleDatabase;
-  let db: Database<ReturnType<typeof sqliteConnector>>;
+  let db: Database;
 
   beforeAll(async () => {
     db = createDatabase(sqliteConnector({}));


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Resolves #131 

A non-breaking change that adds `getInstance` (following the naming convention from `unstorage`) to access a fully typed database client used internally.

#### Notes
- `planetscale` not tested yet