### PR TITLE
build: generate drivers meta

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: "pnpm"
       - run: pnpm install
+      - run: pnpm run gen-connectors
       - run: pnpm automd
       - run: pnpm lint:fix
       - uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 connectors
 integrations
+src/_connectors.ts
 dist
+node_modules
+.output

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "integrations"
   ],
   "scripts": {
-    "build": "unbuild",
+    "build": "pnpm gen-connectors && unbuild",
+    "gen-connectors": "jiti scripts/gen-connectors.ts",
     "db0": "pnpm jiti src/cli",
     "dev": "vitest",
     "lint": "eslint . && prettier -c src test",
@@ -66,19 +67,21 @@
     "eslint": "^9.17.0",
     "eslint-config-unjs": "^0.4.2",
     "jiti": "^2.4.2",
+    "mlly": "^1.7.3",
     "mysql2": "^3.11.5",
     "pg": "^8.13.1",
     "prettier": "^3.4.2",
+    "scule": "^1.3.0",
     "typescript": "^5.7.2",
     "unbuild": "^3.0.1",
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
+    "@electric-sql/pglite": "*",
     "@libsql/client": "*",
     "better-sqlite3": "*",
     "drizzle-orm": "*",
-    "mysql2": "*",
-    "@electric-sql/pglite": "*"
+    "mysql2": "*"
   },
   "peerDependenciesMeta": {
     "@libsql/client": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       jiti:
         specifier: ^2.4.2
         version: 2.4.2
+      mlly:
+        specifier: ^1.7.3
+        version: 1.7.3
       mysql2:
         specifier: ^3.11.5
         version: 3.11.5
@@ -65,6 +68,9 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
+      scule:
+        specifier: ^1.3.0
+        version: 1.3.0
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -2381,6 +2387,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:

--- a/scripts/gen-connectors.ts
+++ b/scripts/gen-connectors.ts
@@ -102,9 +102,9 @@ export type BuiltinConnectorOptions = {
     .join("\n  ")}
 };
 
-export const builtinConnectors = {
+export const builtinConnectors = Object.freeze({
   ${connectors.flatMap((d) => d.names.map((name, i) => `${i === 0 ? "" : `/** @deprecated Alias of ${d.name} */\n  `}"${name}": "${d.subpath}"`)).join(",\n  ")},
-} as const;
+} as const);
 `;
 
 await writeFile(connectorsMetaFile, genCode, "utf8");

--- a/scripts/gen-connectors.ts
+++ b/scripts/gen-connectors.ts
@@ -1,0 +1,92 @@
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findTypeExports } from "mlly";
+import { camelCase, upperFirst } from "scule";
+
+const connectorsDir = fileURLToPath(new URL("../src/connectors", import.meta.url));
+
+const connectorsMetaFile = fileURLToPath(
+  new URL("../src/_connectors.ts", import.meta.url)
+);
+
+async function getConnectorFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...await getConnectorFiles(join(dir, entry.name)));
+    } else if (entry.isFile()) {
+      files.push(join(dir, entry.name));
+    }
+  }
+
+  return files;
+}
+
+const connectorFiles = await getConnectorFiles(connectorsDir);
+const connectorEntries = connectorFiles.map((file) => file.replace(connectorsDir + "/", ""));
+
+const connectors: {
+  name: string;
+  safeName: string;
+  names: string[];
+  subpath: string;
+  optionsTExport?: string;
+  optionsTName?: string;
+}[] = [];
+
+for (const entry of connectorEntries) {
+  const pathName = entry.replace(/\.ts$/, "");
+  const name = pathName.replace(/\/|\\/g, "-");
+  const subpath = `db0/connectors/${pathName}`;
+  const fullPath = join(connectorsDir, `${pathName}.ts`);
+
+  const contents = await readFile(fullPath, "utf8");
+  const optionsTExport = findTypeExports(contents).find((type) =>
+    type.name?.endsWith("Options")
+  )?.name;
+
+  const safeName = camelCase(name)
+    .replace(/db/i, "DB")
+    .replace("bunSqlite", "bun")
+    .replace("libsqlNode", "libsql");
+
+  const names = [...new Set([name, safeName])];
+
+  const optionsTName = upperFirst(safeName) + "Options";
+
+  connectors.push({
+    name,
+    safeName,
+    names,
+    subpath,
+    optionsTExport,
+    optionsTName,
+  });
+}
+
+const genCode = /* ts */ `// Auto-generated using scripts/gen-connectors.
+// Do not manually edit!
+${connectors
+  .filter((d) => d.optionsTExport)
+  .map(
+    (d) =>
+      /* ts */ `import type { ${d.optionsTExport} as ${d.optionsTName} } from "${d.subpath}";`
+  )
+  .join("\n")}
+export type BuiltinConnectorName = ${connectors.flatMap((d) => d.names.map((name) => `"${name}"`)).join(" | ")};
+export type BuiltinConnectorOptions = {
+  ${connectors
+    .filter((d) => d.optionsTExport)
+    .flatMap((d) => d.names.map((name) => `"${name}": ${d.optionsTName};`))
+    .join("\n  ")}
+};
+export const builtinConnectors = {
+  ${connectors.flatMap((d) => d.names.map((name) => `"${name}": "${d.subpath}"`)).join(",\n  ")},
+} as const;
+`;
+
+await writeFile(connectorsMetaFile, genCode, "utf8");
+console.log("Generated connectors metadata file to", connectorsMetaFile);

--- a/src/_connectors.ts
+++ b/src/_connectors.ts
@@ -34,7 +34,7 @@ export type BuiltinConnectorOptions = {
   "postgresql": PostgreSQLOptions;
 };
 
-export const builtinConnectors = {
+export const builtinConnectors = Object.freeze({
   "better-sqlite3": "db0/connectors/better-sqlite3",
   /** @deprecated Alias of better-sqlite3 */
   "sqlite": "db0/connectors/better-sqlite3",
@@ -52,4 +52,4 @@ export const builtinConnectors = {
   "pglite": "db0/connectors/pglite",
   "planetscale": "db0/connectors/planetscale",
   "postgresql": "db0/connectors/postgresql",
-} as const;
+} as const);

--- a/src/_connectors.ts
+++ b/src/_connectors.ts
@@ -1,52 +1,53 @@
 // Auto-generated using scripts/gen-connectors.
 // Do not manually edit!
-import type { ConnectorOptions as BetterSqlite3Options } from "db0/connectors/better-sqlite3";
-import type { ConnectorOptions as BunOptions } from "db0/connectors/bun-sqlite";
+import type { ConnectorOptions as BetterSQLite3Options } from "db0/connectors/better-sqlite3";
+import type { ConnectorOptions as BunSQLiteOptions } from "db0/connectors/bun-sqlite";
 import type { ConnectorOptions as CloudflareD1Options } from "db0/connectors/cloudflare-d1";
-import type { ConnectorOptions as LibsqlCoreOptions } from "db0/connectors/libsql/core";
-import type { ConnectorOptions as LibsqlHttpOptions } from "db0/connectors/libsql/http";
-import type { ConnectorOptions as LibsqlOptions } from "db0/connectors/libsql/node";
-import type { ConnectorOptions as LibsqlWebOptions } from "db0/connectors/libsql/web";
-import type { ConnectorOptions as Mysql2Options } from "db0/connectors/mysql2";
+import type { ConnectorOptions as LibSQLCoreOptions } from "db0/connectors/libsql/core";
+import type { ConnectorOptions as LibSQLHttpOptions } from "db0/connectors/libsql/http";
+import type { ConnectorOptions as LibSQLNodeOptions } from "db0/connectors/libsql/node";
+import type { ConnectorOptions as LibSQLWebOptions } from "db0/connectors/libsql/web";
+import type { ConnectorOptions as MySQL2Options } from "db0/connectors/mysql2";
 import type { ConnectorOptions as PgliteOptions } from "db0/connectors/pglite";
 import type { ConnectorOptions as PlanetscaleOptions } from "db0/connectors/planetscale";
-import type { ConnectorOptions as PostgresqlOptions } from "db0/connectors/postgresql";
-export type BuiltinConnectorName = "better-sqlite3" | "betterSqlite3" | "bun-sqlite" | "bun" | "cloudflare-d1" | "cloudflareD1" | "libsql-core" | "libsqlCore" | "libsql-http" | "libsqlHttp" | "libsql-node" | "libsql" | "libsql-web" | "libsqlWeb" | "mysql2" | "pglite" | "planetscale" | "postgresql";
+import type { ConnectorOptions as PostgreSQLOptions } from "db0/connectors/postgresql";
+
+export type BuiltinConnectorName = "better-sqlite3" | "sqlite" | "bun-sqlite" | "bun" | "cloudflare-d1" | "libsql-core" | "libsql-http" | "libsql-node" | "libsql" | "libsql-web" | "mysql2" | "pglite" | "planetscale" | "postgresql";
+
 export type BuiltinConnectorOptions = {
-  "better-sqlite3": BetterSqlite3Options;
-  "betterSqlite3": BetterSqlite3Options;
-  "bun-sqlite": BunOptions;
-  "bun": BunOptions;
+  "better-sqlite3": BetterSQLite3Options;
+  /** @deprecated Alias of better-sqlite3 */
+  "sqlite": BetterSQLite3Options;
+  "bun-sqlite": BunSQLiteOptions;
+  /** @deprecated Alias of bun-sqlite */
+  "bun": BunSQLiteOptions;
   "cloudflare-d1": CloudflareD1Options;
-  "cloudflareD1": CloudflareD1Options;
-  "libsql-core": LibsqlCoreOptions;
-  "libsqlCore": LibsqlCoreOptions;
-  "libsql-http": LibsqlHttpOptions;
-  "libsqlHttp": LibsqlHttpOptions;
-  "libsql-node": LibsqlOptions;
-  "libsql": LibsqlOptions;
-  "libsql-web": LibsqlWebOptions;
-  "libsqlWeb": LibsqlWebOptions;
-  "mysql2": Mysql2Options;
+  "libsql-core": LibSQLCoreOptions;
+  "libsql-http": LibSQLHttpOptions;
+  "libsql-node": LibSQLNodeOptions;
+  /** @deprecated Alias of libsql-node */
+  "libsql": LibSQLNodeOptions;
+  "libsql-web": LibSQLWebOptions;
+  "mysql2": MySQL2Options;
   "pglite": PgliteOptions;
   "planetscale": PlanetscaleOptions;
-  "postgresql": PostgresqlOptions;
+  "postgresql": PostgreSQLOptions;
 };
+
 export const builtinConnectors = {
   "better-sqlite3": "db0/connectors/better-sqlite3",
-  "betterSqlite3": "db0/connectors/better-sqlite3",
+  /** @deprecated Alias of better-sqlite3 */
+  "sqlite": "db0/connectors/better-sqlite3",
   "bun-sqlite": "db0/connectors/bun-sqlite",
+  /** @deprecated Alias of bun-sqlite */
   "bun": "db0/connectors/bun-sqlite",
   "cloudflare-d1": "db0/connectors/cloudflare-d1",
-  "cloudflareD1": "db0/connectors/cloudflare-d1",
   "libsql-core": "db0/connectors/libsql/core",
-  "libsqlCore": "db0/connectors/libsql/core",
   "libsql-http": "db0/connectors/libsql/http",
-  "libsqlHttp": "db0/connectors/libsql/http",
   "libsql-node": "db0/connectors/libsql/node",
+  /** @deprecated Alias of libsql-node */
   "libsql": "db0/connectors/libsql/node",
   "libsql-web": "db0/connectors/libsql/web",
-  "libsqlWeb": "db0/connectors/libsql/web",
   "mysql2": "db0/connectors/mysql2",
   "pglite": "db0/connectors/pglite",
   "planetscale": "db0/connectors/planetscale",

--- a/src/_connectors.ts
+++ b/src/_connectors.ts
@@ -1,0 +1,54 @@
+// Auto-generated using scripts/gen-connectors.
+// Do not manually edit!
+import type { ConnectorOptions as BetterSqlite3Options } from "db0/connectors/better-sqlite3";
+import type { ConnectorOptions as BunOptions } from "db0/connectors/bun-sqlite";
+import type { ConnectorOptions as CloudflareD1Options } from "db0/connectors/cloudflare-d1";
+import type { ConnectorOptions as LibsqlCoreOptions } from "db0/connectors/libsql/core";
+import type { ConnectorOptions as LibsqlHttpOptions } from "db0/connectors/libsql/http";
+import type { ConnectorOptions as LibsqlOptions } from "db0/connectors/libsql/node";
+import type { ConnectorOptions as LibsqlWebOptions } from "db0/connectors/libsql/web";
+import type { ConnectorOptions as Mysql2Options } from "db0/connectors/mysql2";
+import type { ConnectorOptions as PgliteOptions } from "db0/connectors/pglite";
+import type { ConnectorOptions as PlanetscaleOptions } from "db0/connectors/planetscale";
+import type { ConnectorOptions as PostgresqlOptions } from "db0/connectors/postgresql";
+export type BuiltinConnectorName = "better-sqlite3" | "betterSqlite3" | "bun-sqlite" | "bun" | "cloudflare-d1" | "cloudflareD1" | "libsql-core" | "libsqlCore" | "libsql-http" | "libsqlHttp" | "libsql-node" | "libsql" | "libsql-web" | "libsqlWeb" | "mysql2" | "pglite" | "planetscale" | "postgresql";
+export type BuiltinConnectorOptions = {
+  "better-sqlite3": BetterSqlite3Options;
+  "betterSqlite3": BetterSqlite3Options;
+  "bun-sqlite": BunOptions;
+  "bun": BunOptions;
+  "cloudflare-d1": CloudflareD1Options;
+  "cloudflareD1": CloudflareD1Options;
+  "libsql-core": LibsqlCoreOptions;
+  "libsqlCore": LibsqlCoreOptions;
+  "libsql-http": LibsqlHttpOptions;
+  "libsqlHttp": LibsqlHttpOptions;
+  "libsql-node": LibsqlOptions;
+  "libsql": LibsqlOptions;
+  "libsql-web": LibsqlWebOptions;
+  "libsqlWeb": LibsqlWebOptions;
+  "mysql2": Mysql2Options;
+  "pglite": PgliteOptions;
+  "planetscale": PlanetscaleOptions;
+  "postgresql": PostgresqlOptions;
+};
+export const builtinConnectors = {
+  "better-sqlite3": "db0/connectors/better-sqlite3",
+  "betterSqlite3": "db0/connectors/better-sqlite3",
+  "bun-sqlite": "db0/connectors/bun-sqlite",
+  "bun": "db0/connectors/bun-sqlite",
+  "cloudflare-d1": "db0/connectors/cloudflare-d1",
+  "cloudflareD1": "db0/connectors/cloudflare-d1",
+  "libsql-core": "db0/connectors/libsql/core",
+  "libsqlCore": "db0/connectors/libsql/core",
+  "libsql-http": "db0/connectors/libsql/http",
+  "libsqlHttp": "db0/connectors/libsql/http",
+  "libsql-node": "db0/connectors/libsql/node",
+  "libsql": "db0/connectors/libsql/node",
+  "libsql-web": "db0/connectors/libsql/web",
+  "libsqlWeb": "db0/connectors/libsql/web",
+  "mysql2": "db0/connectors/mysql2",
+  "pglite": "db0/connectors/pglite",
+  "planetscale": "db0/connectors/planetscale",
+  "postgresql": "db0/connectors/postgresql",
+} as const;

--- a/src/connectors/mysql2.ts
+++ b/src/connectors/mysql2.ts
@@ -2,7 +2,9 @@ import mysql from "mysql2/promise";
 
 import type { Connector, Statement } from "../types";
 
-export default function mysqlConnector(opts: mysql.ConnectionOptions) {
+export type ConnectorOptions = mysql.ConnectionOptions
+
+export default function mysqlConnector(opts: ConnectorOptions) {
   let _connection: mysql.Connection | undefined;
   const getConnection = async () => {
     if (_connection) {

--- a/src/connectors/planetscale.ts
+++ b/src/connectors/planetscale.ts
@@ -2,7 +2,9 @@ import { Client, type Config } from "@planetscale/database";
 
 import type { Connector, Statement } from "../types";
 
-export default function planetscaleConnector(opts: Config) {
+export type ConnectorOptions = Config
+
+export default function planetscaleConnector(opts: ConnectorOptions) {
   let _client: undefined | Client;
   function getClient() {
     if (_client) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,29 +8,3 @@ export type {
   SQLDialect,
   Statement,
 } from "./types";
-
-/**
- * A mapping of available database connector identifiers to their module paths.
- * This constant facilitates the use of different database connectors by providing easy access to the
- * by providing easy access to the connector's specific import paths.
- */
-export const connectors = {
-  sqlite: "db0/connectors/better-sqlite3",
-  postgresql: "db0/connectors/postgresql",
-  pglite: "db0/connectors/pglite",
-  "cloudflare-d1": "db0/connectors/cloudflare-d1",
-  libsql: "db0/connectors/libsql/node",
-  "libsql-node": "db0/connectors/libsql/node",
-  "libsql-http": "db0/connectors/libsql/http",
-  "libsql-web": "db0/connectors/libsql/web",
-  bun: "db0/connectors/bun-sqlite",
-  "bun-sqlite": "db0/connectors/bun-sqlite",
-  planetscale: "db0/connectors/planetscale",
-  mysql: "db0/connectors/mysql2",
-} as const;
-
-/**
- * Type alias for the keys of the {@link connectors} map.
- * Represents the names of available database connectors.
- */
-export type ConnectorName = keyof typeof connectors;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,10 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "paths": {
+      "db0/connectors/*": ["./src/connectors/*"]
+    }
   },
   "include": [
     "src"


### PR DESCRIPTION
Following the concept from https://github.com/unjs/unstorage/pull/526

This PR introduces a Auto-generate meta data for `builtinConnectors`, `BuiltinConnectorName` and `BuiltinConnectorOptions` with consistent `kebab-case` + `camelCase` variants to all exports.

Another change in this PR is that it fixes a missing type export for `mysql2` and `planetscale`

<details>
<summary>Details</summary>

```ts
// Auto-generated using scripts/gen-connectors.
// Do not manually edit!

import type { ConnectorOptions as BetterSqlite3Options } from "db0/connectors/better-sqlite3";
import type { ConnectorOptions as BunOptions } from "db0/connectors/bun-sqlite";
import type { ConnectorOptions as CloudflareD1Options } from "db0/connectors/cloudflare-d1";
import type { ConnectorOptions as LibsqlCoreOptions } from "db0/connectors/libsql/core";
import type { ConnectorOptions as LibsqlHttpOptions } from "db0/connectors/libsql/http";
import type { ConnectorOptions as LibsqlOptions } from "db0/connectors/libsql/node";
import type { ConnectorOptions as LibsqlWebOptions } from "db0/connectors/libsql/web";
import type { ConnectorOptions as Mysql2Options } from "db0/connectors/mysql2";
import type { ConnectorOptions as PgliteOptions } from "db0/connectors/pglite";
import type { ConnectorOptions as PlanetscaleOptions } from "db0/connectors/planetscale";
import type { ConnectorOptions as PostgresqlOptions } from "db0/connectors/postgresql";

export type BuiltinConnectorName = "better-sqlite3" | "betterSqlite3" | "bun-sqlite" | "bun" | "cloudflare-d1" | "cloudflareD1" | "libsql-core" | "libsqlCore" | "libsql-http" | "libsqlHttp" | "libsql-node" | "libsql" | "libsql-web" | "libsqlWeb" | "mysql2" | "pglite" | "planetscale" | "postgresql";

export type BuiltinConnectorOptions = {
  "better-sqlite3": BetterSqlite3Options;
  "betterSqlite3": BetterSqlite3Options;
  "bun-sqlite": BunOptions;
  "bun": BunOptions;
  "cloudflare-d1": CloudflareD1Options;
  "cloudflareD1": CloudflareD1Options;
  "libsql-core": LibsqlCoreOptions;
  "libsqlCore": LibsqlCoreOptions;
  "libsql-http": LibsqlHttpOptions;
  "libsqlHttp": LibsqlHttpOptions;
  "libsql-node": LibsqlOptions;
  "libsql": LibsqlOptions;
  "libsql-web": LibsqlWebOptions;
  "libsqlWeb": LibsqlWebOptions;
  "mysql2": Mysql2Options;
  "pglite": PgliteOptions;
  "planetscale": PlanetscaleOptions;
  "postgresql": PostgresqlOptions;
};

export const builtinConnectors = {
  "better-sqlite3": "db0/connectors/better-sqlite3",
  "betterSqlite3": "db0/connectors/better-sqlite3",
  "bun-sqlite": "db0/connectors/bun-sqlite",
  "bun": "db0/connectors/bun-sqlite",
  "cloudflare-d1": "db0/connectors/cloudflare-d1",
  "cloudflareD1": "db0/connectors/cloudflare-d1",
  "libsql-core": "db0/connectors/libsql/core",
  "libsqlCore": "db0/connectors/libsql/core",
  "libsql-http": "db0/connectors/libsql/http",
  "libsqlHttp": "db0/connectors/libsql/http",
  "libsql-node": "db0/connectors/libsql/node",
  "libsql": "db0/connectors/libsql/node",
  "libsql-web": "db0/connectors/libsql/web",
  "libsqlWeb": "db0/connectors/libsql/web",
  "mysql2": "db0/connectors/mysql2",
  "pglite": "db0/connectors/pglite",
  "planetscale": "db0/connectors/planetscale",
  "postgresql": "db0/connectors/postgresql",
} as const;
```
</details>