### PR TITLE
fix(bun-sqlite): remove in-memory fallback when name is not provided

### DIFF
--- a/src/connectors/bun-sqlite.ts
+++ b/src/connectors/bun-sqlite.ts
@@ -16,7 +16,7 @@ export default function bunSqliteConnector(opts: ConnectorOptions) {
     if (_db) {
       return _db;
     }
-    if (!opts.name || opts.name === ":memory:") {
+    if (opts.name === ":memory:") {
       _db = new Database(":memory:");
     } else {
       const filePath = resolve(


### PR DESCRIPTION
This PR should resolve the issue in @nuxt/content repository - https://github.com/nuxt/content/issues/3118

https://github.com/unjs/db0/blob/11c2bf253084b9abc2184bafdbee71f4f5652927/src/connectors/bun-sqlite.ts#L19

We don't want to create in-memory database when the name is not provided. This just doesn't make any sense. 

In @nuxt/content the options for connector include only `path` property with absolute path to file. They don't include name. With such condition `!opts.name` in branch for in-memory db we unable to access else branch which is where we expected to be. 

In better-sqlite3 connector we don't have such condition:

https://github.com/unjs/db0/blob/11c2bf253084b9abc2184bafdbee71f4f5652927/src/connectors/better-sqlite3.ts#L19
