### PR TITLE
feat: `node-sqlite` driver with native `node:sqlite`

### DIFF
--- a/src/_connectors.ts
+++ b/src/_connectors.ts
@@ -8,12 +8,13 @@ import type { ConnectorOptions as LibSQLHttpOptions } from "db0/connectors/libsq
 import type { ConnectorOptions as LibSQLNodeOptions } from "db0/connectors/libsql/node";
 import type { ConnectorOptions as LibSQLWebOptions } from "db0/connectors/libsql/web";
 import type { ConnectorOptions as MySQL2Options } from "db0/connectors/mysql2";
+import type { ConnectorOptions as NodeSQLiteOptions } from "db0/connectors/node-sqlite";
 import type { ConnectorOptions as NodeSQLite3Options } from "db0/connectors/node-sqlite3";
 import type { ConnectorOptions as PgliteOptions } from "db0/connectors/pglite";
 import type { ConnectorOptions as PlanetscaleOptions } from "db0/connectors/planetscale";
 import type { ConnectorOptions as PostgreSQLOptions } from "db0/connectors/postgresql";
 
-export type ConnectorName = "better-sqlite3" | "sqlite" | "bun-sqlite" | "bun" | "cloudflare-d1" | "libsql-core" | "libsql-http" | "libsql-node" | "libsql" | "libsql-web" | "mysql2" | "node-sqlite3" | "pglite" | "planetscale" | "postgresql";
+export type ConnectorName = "better-sqlite3" | "sqlite" | "bun-sqlite" | "bun" | "cloudflare-d1" | "libsql-core" | "libsql-http" | "libsql-node" | "libsql" | "libsql-web" | "mysql2" | "node-sqlite" | "node-sqlite3" | "pglite" | "planetscale" | "postgresql";
 
 export type ConnectorOptions = {
   "better-sqlite3": BetterSQLite3Options;
@@ -30,6 +31,7 @@ export type ConnectorOptions = {
   "libsql": LibSQLNodeOptions;
   "libsql-web": LibSQLWebOptions;
   "mysql2": MySQL2Options;
+  "node-sqlite": NodeSQLiteOptions;
   "node-sqlite3": NodeSQLite3Options;
   "pglite": PgliteOptions;
   "planetscale": PlanetscaleOptions;
@@ -51,6 +53,7 @@ export const connectors = Object.freeze({
   "libsql": "db0/connectors/libsql/node",
   "libsql-web": "db0/connectors/libsql/web",
   "mysql2": "db0/connectors/mysql2",
+  "node-sqlite": "db0/connectors/node-sqlite",
   "node-sqlite3": "db0/connectors/node-sqlite3",
   "pglite": "db0/connectors/pglite",
   "planetscale": "db0/connectors/planetscale",

--- a/src/connectors/node-sqlite.ts
+++ b/src/connectors/node-sqlite.ts
@@ -1,0 +1,68 @@
+import { resolve, dirname } from 'node:path'
+import { mkdirSync } from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
+import type { Connector, Statement, Primitive } from "../types";
+
+export interface ConnectorOptions {
+  cwd?: string
+  path?: string
+  name?: string
+}
+
+export default function nodeSqlite3Connector(opts: ConnectorOptions) {
+  let _db: DatabaseSync | undefined
+
+  const getDB = () => {
+    if (_db) {
+      return _db
+    }
+    if (opts.name === ':memory:') {
+      _db = new DatabaseSync(':memory:')
+      return _db
+    }
+    const filePath = resolve(
+      opts.cwd || '.',
+      opts.path || `.data/${opts.name || 'db'}.sqlite3`,
+    )
+    mkdirSync(dirname(filePath), { recursive: true })
+    _db = new DatabaseSync(filePath)
+    return _db
+  }
+
+  return <Connector<DatabaseSync>>{
+    name: 'node-sqlite',
+    dialect: 'sqlite',
+    getInstance: () => getDB(),
+    exec(sql: string) {
+      getDB().exec(sql)
+      return { success: true }
+    },
+    prepare(sql: string) {
+      // TODO: investgate if it is really a Node.js limit or types issue
+      type SupportedValueTypes = Array<Exclude<Primitive, boolean>>
+
+      const _stmt = getDB().prepare(sql)
+
+      let bindParams: SupportedValueTypes | undefined
+
+      const stmt = <Statement>{
+        bind(...params) {
+          bindParams = params as SupportedValueTypes
+        },
+        all(...callParams) {
+          const params = callParams.length > 0 ? callParams : (bindParams || [])
+          return _stmt.all(...params as SupportedValueTypes) as any
+        },
+        run(...callParams) {
+          const params = callParams.length > 0 ? callParams : (bindParams || [])
+          return _stmt.run(...params as SupportedValueTypes) as any
+        },
+        get(...callParams) {
+          const params = callParams.length > 0 ? callParams : (bindParams || [])
+          return _stmt.get(...params as SupportedValueTypes) as any
+        },
+      }
+      return stmt
+    },
+  }
+}

--- a/test/connectors/node-sqlite.test.ts
+++ b/test/connectors/node-sqlite.test.ts
@@ -1,0 +1,12 @@
+import { describe } from "vitest";
+import connector from "../../src/connectors/node-sqlite";
+import { testConnector } from "./_tests";
+
+describe("connectors: node-sqlite (native)", () => {
+  testConnector({
+    dialect: "sqlite",
+    connector: connector({
+      name: ":memory:",
+    }),
+  });
+});


### PR DESCRIPTION
Add new `node-sqlite` driver using native [`node:sqlite`](https://nodejs.org/api/sqlite.html) supported in Node.js >= 22.5 (experimental) and Deno >= [2.2](https://deno.com/blog/v2.2)