### PR TITLE
feat!: prepared statements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-POSTGRESQL_URL=postgresql://<user>:@localhost:5432/db0
-MYSQL_URL=
+POSTGRESQL_URL=postgresql://test:test@localhost:5432/db0
+MYSQL_URL=mysql://test:test@localhost:3306/db0
 
 # PlanetScale
 PLANETSCALE_HOST=aws.connect.psdb.cloud

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  pg:
+    # https://hub.docker.com/_/postgres
+    image: postgres:alpine
+    network_mode: "host"
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: db0
+  mysql:
+    # https://hub.docker.com/_/mysql
+    image: mysql
+    network_mode: "host"
+    environment:
+      MYSQL_ROOT_PASSWORD: test
+      MYSQL_DATABASE: db0
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test

--- a/scripts/gen-connectors.ts
+++ b/scripts/gen-connectors.ts
@@ -23,6 +23,9 @@ async function getConnectorFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
 
   for (const entry of entries) {
+    if (entry.name.startsWith("_")) {
+      continue;
+    }
     if (entry.isDirectory()) {
       files.push(...(await getConnectorFiles(join(dir, entry.name))));
     } else if (entry.isFile()) {

--- a/src/connectors/_internal/statement.ts
+++ b/src/connectors/_internal/statement.ts
@@ -1,0 +1,45 @@
+import type { Primitive, Statement, PreparedStatement } from "../../types";
+
+export abstract class BoundableStatement<T> implements Statement {
+  _rawStmt: T;
+
+  constructor(rawStmt: T) {
+    this._rawStmt = rawStmt;
+  }
+
+  bind(...params: Primitive[]): PreparedStatement {
+    return new BoundStatement(this, params);
+  }
+
+  abstract all(...params: Primitive[]): Promise<unknown[]>;
+
+  abstract run(...params: Primitive[]): Promise<{ success: boolean }>;
+
+  abstract get(...params: Primitive[]): Promise<unknown>;
+}
+
+class BoundStatement<S extends Statement> implements PreparedStatement {
+  #statement: S;
+  #params: Primitive[];
+
+  constructor(statement: S, params: Primitive[]) {
+    this.#statement = statement;
+    this.#params = params;
+  }
+
+  bind(...params: Primitive[]): BoundStatement<S> {
+    return new BoundStatement(this.#statement, params);
+  }
+
+  all(): Promise<unknown[]> {
+    return this.#statement.all(...this.#params);
+  }
+
+  run(): Promise<{ success: boolean }> {
+    return this.#statement.run(...this.#params);
+  }
+
+  get(): Promise<unknown> {
+    return this.#statement.get(...this.#params);
+  }
+}

--- a/src/connectors/_internal/statement.ts
+++ b/src/connectors/_internal/statement.ts
@@ -1,10 +1,10 @@
 import type { Primitive, Statement, PreparedStatement } from "../../types";
 
 export abstract class BoundableStatement<T> implements Statement {
-  _rawStmt: T;
+  _statement: T;
 
   constructor(rawStmt: T) {
-    this._rawStmt = rawStmt;
+    this._statement = rawStmt;
   }
 
   bind(...params: Primitive[]): PreparedStatement {

--- a/src/connectors/better-sqlite3.ts
+++ b/src/connectors/better-sqlite3.ts
@@ -41,15 +41,15 @@ export default function sqliteConnector(opts: ConnectorOptions) {
 
 class StatementWrapper extends BoundableStatement<RawStatement> {
   all(...params) {
-    return Promise.resolve(this._rawStmt.all(...params));
+    return Promise.resolve(this._statement.all(...params));
   }
 
   run(...params) {
-    const res = this._rawStmt.run(...params);
+    const res = this._statement.run(...params);
     return Promise.resolve({ success: res.changes > 0, ...res });
   }
 
   get(...params) {
-    return Promise.resolve(this._rawStmt.get(...params));
+    return Promise.resolve(this._statement.get(...params));
   }
 }

--- a/src/connectors/better-sqlite3.ts
+++ b/src/connectors/better-sqlite3.ts
@@ -1,8 +1,9 @@
 import { resolve, dirname } from "node:path";
 import { mkdirSync } from "node:fs";
 import Database from "better-sqlite3";
-
-import type { Connector, Statement } from "../types";
+import type { Connector } from "../types";
+import type { Statement as RawStatement } from 'better-sqlite3'
+import { BoundableStatement } from "./_internal/statement";
 
 export interface ConnectorOptions {
   cwd?: string;
@@ -33,30 +34,22 @@ export default function sqliteConnector(opts: ConnectorOptions) {
     name: "sqlite",
     dialect: "sqlite",
     getInstance: () => getDB(),
-    exec(sql: string) {
-      return getDB().exec(sql);
-    },
-    prepare(sql: string) {
-      const _stmt = getDB().prepare(sql);
-      const stmt = <Statement>{
-        bind(...params) {
-          if (params.length > 0) {
-            _stmt.bind(...params);
-          }
-          return stmt;
-        },
-        all(...params) {
-          return Promise.resolve(_stmt.all(...params));
-        },
-        run(...params) {
-          const res = _stmt.run(...params);
-          return Promise.resolve({ success: res.changes > 0 });
-        },
-        get(...params) {
-          return Promise.resolve(_stmt.get(...params));
-        },
-      };
-      return stmt;
-    },
+    exec: sql => getDB().exec(sql),
+    prepare: sql => new StatementWrapper(getDB().prepare(sql))
   };
+}
+
+class StatementWrapper extends BoundableStatement<RawStatement> {
+  all(...params) {
+    return Promise.resolve(this._rawStmt.all(...params));
+  }
+
+  run(...params) {
+    const res = this._rawStmt.run(...params);
+    return Promise.resolve({ success: res.changes > 0, ...res });
+  }
+
+  get(...params) {
+    return Promise.resolve(this._rawStmt.get(...params));
+  }
 }

--- a/src/connectors/bun-sqlite.ts
+++ b/src/connectors/bun-sqlite.ts
@@ -40,15 +40,15 @@ export default function bunSqliteConnector(opts: ConnectorOptions) {
 
 class StatementWrapper extends BoundableStatement<RawStatement> {
   all(...params) {
-    return Promise.resolve(this._rawStmt.all(...params));
+    return Promise.resolve(this._statement.all(...params));
   }
 
   run(...params) {
-    const res = this._rawStmt.run(...params);
+    const res = this._statement.run(...params);
     return Promise.resolve({ success: true, ...res });
   }
 
   get(...params) {
-    return Promise.resolve(this._rawStmt.get(...params));
+    return Promise.resolve(this._statement.get(...params));
   }
 }

--- a/src/connectors/cloudflare-d1.ts
+++ b/src/connectors/cloudflare-d1.ts
@@ -27,17 +27,17 @@ export default function cloudflareD1Connector(options: ConnectorOptions) {
 
 class StatementWrapper extends BoundableStatement<RawStatement> {
   async all(...params) {
-    const res = await this._rawStmt.bind(...params).all()
+    const res = await this._statement.bind(...params).all()
     return res.results
   }
 
   async run(...params) {
-    const res = await this._rawStmt.bind(...params).run()
+    const res = await this._statement.bind(...params).run()
     return res
   }
 
   async get(...params) {
-    const res = await this._rawStmt.bind(...params).first()
+    const res = await this._statement.bind(...params).first()
     return res
   }
 }

--- a/src/connectors/node-sqlite3.ts
+++ b/src/connectors/node-sqlite3.ts
@@ -51,19 +51,19 @@ export default function nodeSqlite3Connector(opts: ConnectorOptions) {
 class StatementWrapper extends BoundableStatement<sqlite3.Statement> {
   async all(...params) {
     const rows = await new Promise<unknown[]>((resolve, reject) => {
-      this._rawStmt.all(...params, (err, rows) => err ? reject(err) : resolve(rows))
+      this._statement.all(...params, (err, rows) => err ? reject(err) : resolve(rows))
     })
     return rows
   }
   async run(...params) {
     await new Promise<void>((resolve, reject) => {
-      this._rawStmt.run(...params, (err) => err ? reject(err) : resolve())
+      this._statement.run(...params, (err) => err ? reject(err) : resolve())
     })
     return { success: true }
   }
   async get(...params) {
     const row = await new Promise((resolve, reject) => {
-      this._rawStmt.get(...params, (err, row) => err ? reject(err) : resolve(row))
+      this._statement.get(...params, (err, row) => err ? reject(err) : resolve(row))
     })
     return row
   }

--- a/src/connectors/pglite.ts
+++ b/src/connectors/pglite.ts
@@ -1,8 +1,11 @@
-import type { PGliteOptions, PGliteInterfaceExtensions } from "@electric-sql/pglite";
+import type { PGliteOptions, PGliteInterfaceExtensions, Results as PGLiteQueryResults } from "@electric-sql/pglite";
 import { PGlite } from "@electric-sql/pglite";
-import type { Connector, Statement } from "../types";
+import type { Connector } from "../types";
+import { BoundableStatement } from "./_internal/statement";
 
 export type ConnectorOptions = PGliteOptions
+
+type InternalQuery = (sql: string, params?: unknown[]) => Promise<PGLiteQueryResults>
 
 export default function pgliteConnector<TOptions extends ConnectorOptions>(opts?: TOptions) {
   type PGLiteInstance = PGlite & PGliteInterfaceExtensions<TOptions['extensions']>
@@ -13,7 +16,7 @@ export default function pgliteConnector<TOptions extends ConnectorOptions>(opts?
     return _client ||= PGlite.create(opts).then((res) => _client = res)
   }
 
-  async function query(sql: string, params: unknown[] = undefined) {
+  const query: InternalQuery = async (sql, params) =>{
     const client = await getClient();
     const normalizedSql = normalizeParams(sql);
     const result = await client.query(normalizedSql, params);
@@ -24,52 +27,52 @@ export default function pgliteConnector<TOptions extends ConnectorOptions>(opts?
     name: "pglite",
     dialect: "postgresql",
     getInstance: () => getClient(),
-    exec(sql: string) {
-      return query(sql);
-    },
-    prepare(sql: string) {
-      const stmt = <Statement>{
-        _sql: sql,
-        _params: [],
-        bind(...params: unknown[]) {
-          if (params.length > 0) {
-            this._params = params;
-          }
-          return this;
-        },
-        async all(...params: unknown[]) {
-          const result = await query(
-            this._sql,
-            params.length > 0 ? params : this._params
-          );
-          return result.rows;
-        },
-        async run(...params: unknown[]) {
-          const result = await query(
-            this._sql,
-            params.length > 0 ? params : this._params
-          );
-          return {
-            success: true,  // Adding the success property to match the expected type
-            result,
-            rows: result.rows,
-          };
-        },
-        async get(...params: unknown[]) {
-          const result = await query(
-            this._sql,
-            params.length > 0 ? params : this._params
-          );
-          return result.rows[0];
-        },
-      };
-      return stmt;
-    },
+    exec: sql => query(sql),
+    prepare: sql => new StatementWrapper(sql, query)
   };
 }
+
 
 // https://www.postgresql.org/docs/9.3/sql-prepare.html
 function normalizeParams(sql: string) {
   let i = 0;
   return sql.replace(/\?/g, () => `$${++i}`);
+}
+
+class StatementWrapper extends BoundableStatement<void> {
+  #query: InternalQuery;
+  #sql: string;
+
+  constructor(sql: string, query: InternalQuery) {
+    super();
+    this.#sql = sql;
+    this.#query = query;
+  }
+
+  async all(...params) {
+    const result = await this.#query(
+      this.#sql,
+      params
+    );
+    return result.rows;
+  }
+
+  async run(...params) {
+    const result = await this.#query(
+      this.#sql,
+      params
+    );
+    return {
+      success: true,
+      ...result,
+    };
+  }
+
+  async get(...params) {
+    const result = await this.#query(
+      this.#sql,
+      params
+    );
+    return result.rows[0];
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,11 +7,11 @@ export type SQLDialect = "mysql" | "postgresql" | "sqlite" | "libsql";
 
 export type Statement = {
   /**
-   * Binds parameters to the statement and returns itself for concatenation.
+   * Binds parameters to the statement.
    * @param {...Primitive[]} params - Parameters to bind to the SQL statement.
-   * @returns {Statement} The instance of the statement for further cascading.
+   * @returns {PreparedStatement} The instance of the statement with bound parameters.
    */
-  bind(...params: Primitive[]): Statement;
+  bind(...params: Primitive[]): PreparedStatement;
 
   /**
    * Executes the statement and returns all resulting rows as an array.
@@ -33,6 +33,33 @@ export type Statement = {
    * @returns {Promise<unknown>} A promise that resolves to the first row in the result set.
    */
   get(...params: Primitive[]): Promise<unknown>;
+};
+
+export type PreparedStatement = {
+  /**
+   * Binds parameters to the statement.
+   * @param {...Primitive[]} params - Parameters to bind to the SQL statement.
+   * @returns {PreparedStatement} The instance of the statement with bound parameters.
+   */
+  bind(...params: Primitive[]): PreparedStatement;
+
+  /**
+   * Executes the statement and returns all resulting rows as an array.
+   * @returns {Promise<unknown[]>} A promise that resolves to an array of rows.
+   */
+  all(): Promise<unknown[]>;
+
+  /**
+   * Executes the statement as an action (e.g. insert, update, delete).
+   * @returns {Promise<{ success: boolean }>} A promise that resolves to the success state of the action.
+   */
+  run(): Promise<{ success: boolean }>;
+
+  /**
+   * Executes the statement and returns a single row.
+   * @returns {Promise<unknown>} A promise that resolves to the first row in the result set.
+   */
+  get(): Promise<unknown>;
 };
 
 /**

--- a/test/connectors/mysql2.test.ts
+++ b/test/connectors/mysql2.test.ts
@@ -9,8 +9,8 @@ describe.runIf(process.env.MYSQL_URL)(
       dialect: "mysql",
       connector: connector({
         host: "localhost",
-        user: "root",
-        password: "root",
+        user: "test",
+        password: "test",
         database: "db0",
       }),
     });


### PR DESCRIPTION
Prepared statement handling was inconsistent between connectors and also could not be nested.

This PR uses a unified class based implementation for `.prepare()` that returns a new `PreparedStatement` interface (methods, no longer accept params as it is prepared already but can be cached with another `.prepare()`)