### PR TITLE
fix(kysely): run non-returning mutations

### DIFF
--- a/src/integrations/kysely/_dialect.ts
+++ b/src/integrations/kysely/_dialect.ts
@@ -29,6 +29,9 @@ export class DB0Connection implements DatabaseConnection {
     }
 
     const rows = (await stmt.all(...(parameters as Primitive[]))) as R[];
+    if (!isMutation) {
+      return { rows };
+    }
     return {
       rows,
       // db0 does not expose numAffectedRows/insertId,

--- a/src/integrations/kysely/_dialect.ts
+++ b/src/integrations/kysely/_dialect.ts
@@ -11,24 +11,30 @@ export class DB0Connection implements DatabaseConnection {
     const { sql, parameters } = compiledQuery;
     const stmt = this.db.prepare(sql);
 
-    if (
+    const isMutation =
       compiledQuery.query.kind === "InsertQueryNode" ||
       compiledQuery.query.kind === "UpdateQueryNode" ||
       compiledQuery.query.kind === "DeleteQueryNode" ||
-      compiledQuery.query.kind === "MergeQueryNode"
+      compiledQuery.query.kind === "MergeQueryNode";
+
+    if (
+      isMutation &&
+      !("returning" in compiledQuery.query && compiledQuery.query.returning)
     ) {
-      // For mutations that may return rows (RETURNING clause)
-      const rows = (await stmt.all(...(parameters as Primitive[]))) as R[];
-      return {
-        rows,
-        // db0 doesn't expose numAffectedRows/insertId,
-        // but rows from RETURNING give the needed info
-        numAffectedRows: rows.length > 0 ? BigInt(rows.length) : undefined,
-      };
+      // Mutation statements without RETURNING do not produce rows. Calling
+      // Statement.all() is rejected by drivers such as better-sqlite3; run()
+      // executes them and Kysely only needs an empty rows array here.
+      await stmt.run(...(parameters as Primitive[]));
+      return { rows: [] };
     }
 
     const rows = (await stmt.all(...(parameters as Primitive[]))) as R[];
-    return { rows };
+    return {
+      rows,
+      // db0 does not expose numAffectedRows/insertId,
+      // but rows from RETURNING give the needed info
+      numAffectedRows: rows.length > 0 ? BigInt(rows.length) : undefined,
+    };
   }
 
   // eslint-disable-next-line require-yield

--- a/test/integrations/kysely/sqlite.test.ts
+++ b/test/integrations/kysely/sqlite.test.ts
@@ -5,6 +5,7 @@ import { kysely } from "../../../src/integrations/kysely";
 
 import type { Kysely } from "kysely";
 
+import betterSqlite3 from "../../../src/connectors/better-sqlite3";
 import libsqlNode from "../../../src/connectors/libsql/node";
 
 interface UsersTable {
@@ -17,6 +18,10 @@ interface DB {
 }
 
 const connectors: { name: string; connector: () => Connector }[] = [
+  {
+    name: "better-sqlite3",
+    connector: () => betterSqlite3({ name: ":memory:" }),
+  },
   {
     name: "libsql-node",
     connector: () => libsqlNode({ url: ":memory:" }),
@@ -106,6 +111,7 @@ for (const { name, connector } of connectors) {
 
     afterAll(async () => {
       await db.sql`DROP TABLE IF EXISTS users`;
+      await db.dispose();
     });
   });
 }


### PR DESCRIPTION
## Problem

The Kysely adapter currently calls db0 Statement.all() for every insert, update, delete, and merge query, including mutations without a RETURNING clause. Drivers such as better-sqlite3 reject all for statements that do not return rows, so standard non-returning Kysely mutations fail.

## Fix

Inspect the compiled Kysely mutation node and use Statement.run() when it has no returning clause. Returning mutations continue to use all(). The SQLite integration matrix now exercises the same mutation and transaction cases with better-sqlite3 as well as libsql-node.

## Tests

- pnpm vitest run test/integrations/kysely/sqlite.test.ts - passed; 12 tests
- pnpm lint - passed
- pnpm test:types - passed
- pnpm build - passed
- pnpm prisma:generate - passed
- pnpm vitest run --coverage --maxWorkers=1 - passed; 289 tests, 86 skipped

## Compatibility

The public API is unchanged. Returning mutations retain the existing all path; non-returning mutation execution uses the driver's run method and returns an empty row list to Kysely.

## Related issue

Independent reproduction; no existing issue or pull request for this exact behavior was found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQLite insert, update, delete, and merge operations without a `RETURNING` clause.
  * These operations now complete successfully and report affected-row results without triggering driver errors.
  * Queries using `RETURNING` continue to return their result rows as expected.

* **Testing**
  * Expanded SQLite integration coverage to include the better-sqlite3 connector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->